### PR TITLE
Added missing links for clef 2023 and 2020

### DIFF
--- a/onboarding_papers/Acoustic_Species_ID.bib
+++ b/onboarding_papers/Acoustic_Species_ID.bib
@@ -12,6 +12,7 @@
   title={Overview of BirdCLEF 2023: Automated bird species identification in Eastern Africa},
   author={Kahl, Stefan and Denton, Tom and Klinck, Holger and Reers, Hendrik and Cherutich, Francis and Glotin, Herv{\'e} and Go{\"e}au, Herv{\'e} and Vellinga, Willem-Pier and Planqu{\'e}, Robert and Joly, Alexis},
   journal={Working Notes of CLEF},
+  url={https://www.researchgate.net/publication/373603820_Overview_of_BirdCLEF_2023_Automated_Bird_Species_Identification_in_Eastern_Africa_40_International_CC_BY_40},
   year={2023}
 }
 @inproceedings{kahl_clapp_hopping_et_al_CLEF_2020,
@@ -20,5 +21,6 @@
   booktitle={CLEF 2020-Conference and Labs of the Evaluation Forum},
   volume={2696},
   number={262},
+  url={https://ceur-ws.org/Vol-2696/paper_262.pdf},
   year={2020}
 }


### PR DESCRIPTION
The workshop paper for 2023 is in progress, and will likely be found in the near future at https://ceur-ws.org/ but for now, I am using the file from reserachgate as uploaded by the author. 